### PR TITLE
Add archived flag to querystring

### DIFF
--- a/app/services/github.ts
+++ b/app/services/github.ts
@@ -57,7 +57,7 @@ export async function fetchGitHubIssues(params: FilterParams) {
     }
   `
 
-  let queryString = 'is:open is:issue label:"good first issue"'
+  let queryString = 'is:open is:issue label:"good first issue" archived:false'
   if (params.language) queryString += ` language:${params.language}`
   if (params.isAssigned) {
     queryString += " assigned:*"
@@ -161,7 +161,7 @@ export async function fetchGitHubIssuesByCategory(params: FilterParams) {
     }
   `
 
-  let queryString = "is:public"
+  let queryString = "is:public archived:false"
   if (params.language) queryString += ` language:${params.language}`
   queryString += ` stars:${params.minStars}..${params.maxStars}`
 
@@ -294,7 +294,7 @@ export async function fetchGitHubIssuesByFramework(params: FilterParams) {
     }
   `
 
-  let queryString = `topic:${params.framework} is:public`
+  let queryString = `topic:${params.framework} is:public archived:false`
   if (params.language) queryString += ` language:${params.language}`
   queryString += ` stars:${params.minStars}..${params.maxStars}`
 


### PR DESCRIPTION
## Description
Add an archived flag in the query string to filter out issues from archived repositories and get issues only from the active repositories

## ISSUES_ADDRESSED
Fix #38 