### PR TITLE
Feature: Add Min Forks filter

### DIFF
--- a/app/components/FilterForm.tsx
+++ b/app/components/FilterForm.tsx
@@ -27,6 +27,7 @@ type FilterFormProps = {
   service: Service
   minStars: string
   maxStars: string
+  minForks: string
   language: string
   isAssigned: boolean
   category: string
@@ -37,6 +38,7 @@ type FilterFormProps = {
   onServiceChange: (value: Service) => void
   onMinStarsChange: (value: string) => void
   onMaxStarsChange: (value: string) => void
+  onMinForksChange: (value: string) => void
   onLanguageChange: (value: string) => void
   onIsAssignedChange: (value: boolean) => void
   onCategoryChange: (value: string) => void
@@ -50,6 +52,7 @@ export function FilterForm({
   service,
   minStars,
   maxStars,
+  minForks,
   language,
   isAssigned,
   category,
@@ -60,6 +63,7 @@ export function FilterForm({
   onServiceChange,
   onMinStarsChange,
   onMaxStarsChange,
+  onMinForksChange,
   onLanguageChange,
   onIsAssignedChange,
   onCategoryChange,
@@ -134,6 +138,7 @@ export function FilterForm({
                       type="number"
                       id="minStars"
                       name="minStars"
+                      min="0"
                       value={minStars}
                       onChange={(e) => onMinStarsChange(e.target.value)}
                       className="bg-white dark:bg-gray-800 text-black dark:text-white p-3 border-2 border-gray-300 dark:border-transparent focus:border-blue-500 focus:outline-none rounded-md transition-colors duration-200"
@@ -149,6 +154,20 @@ export function FilterForm({
                       name="maxStars"
                       value={maxStars}
                       onChange={(e) => onMaxStarsChange(e.target.value)}
+                      className="bg-white dark:bg-gray-800 text-black dark:text-white p-3 border-2 border-gray-300 dark:border-transparent focus:border-blue-500 focus:outline-none rounded-md transition-colors duration-200"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label htmlFor="minStars" className="text-sm font-medium">
+                      Min Forks
+                    </label>
+                    <Input
+                      type="number"
+                      id="minForks"
+                      name="minForks"
+                      value={minForks}
+                      min="0"
+                      onChange={(e) => onMinForksChange(e.target.value)}
                       className="bg-white dark:bg-gray-800 text-black dark:text-white p-3 border-2 border-gray-300 dark:border-transparent focus:border-blue-500 focus:outline-none rounded-md transition-colors duration-200"
                     />
                   </div>

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -26,6 +26,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     service: (url.searchParams.get("service") || "github") as Service,
     minStars: parseInt(url.searchParams.get("minStars") || "0", 10),
     maxStars: parseInt(url.searchParams.get("maxStars") || "1000000", 10),
+    minForks: parseInt(url.searchParams.get("minForks") || "0", 10),
     language: url.searchParams.get("language") || "",
     isAssigned: url.searchParams.get("isAssigned") === "true",
     cursor: url.searchParams.get("cursor") || null,
@@ -82,6 +83,7 @@ export default function Index() {
   const [service, setService] = useState<Service>(initialService)
   const [minStars, setMinStars] = useState("0")
   const [maxStars, setMaxStars] = useState("1000000")
+  const [minForks, setMinForks] = useState("0")
   const [language, setLanguage] = useState("")
   const [isAssigned, setIsAssigned] = useState(false)
   const [category, setCategory] = useState("all")
@@ -98,6 +100,7 @@ export default function Index() {
     setService((url.searchParams.get("service") || "github") as Service)
     setMinStars(url.searchParams.get("minStars") || "0")
     setMaxStars(url.searchParams.get("maxStars") || "1000000")
+    setMinForks(url.searchParams.get("minForks") || "0")
     setLanguage(url.searchParams.get("language") || "")
     setIsAssigned(url.searchParams.get("isAssigned") === "true")
     setCategory(url.searchParams.get("category") || "all")
@@ -141,6 +144,7 @@ export default function Index() {
     formData.set("service", service)
     formData.set("minStars", minStars)
     formData.set("maxStars", maxStars)
+    formData.set("minForks", minForks)
     formData.set("language", language)
     formData.set("isAssigned", isAssigned.toString())
     formData.set("category", category)
@@ -157,6 +161,7 @@ export default function Index() {
     formData.set("service", newService)
     formData.set("minStars", minStars)
     formData.set("maxStars", maxStars)
+    formData.set("minForks", minForks)
     formData.set("language", language)
     formData.set("isAssigned", isAssigned.toString())
     formData.set("category", category)
@@ -194,6 +199,7 @@ export default function Index() {
                 service={service}
                 minStars={minStars}
                 maxStars={maxStars}
+                minForks={minForks}
                 language={language}
                 isAssigned={isAssigned}
                 category={category}
@@ -204,6 +210,7 @@ export default function Index() {
                 onServiceChange={handleServiceChange}
                 onMinStarsChange={setMinStars}
                 onMaxStarsChange={setMaxStars}
+                onMinForksChange={setMinForks}
                 onLanguageChange={setLanguage}
                 onIsAssignedChange={setIsAssigned}
                 onCategoryChange={setCategory}

--- a/app/services/github.ts
+++ b/app/services/github.ts
@@ -33,6 +33,7 @@ export async function fetchGitHubIssues(params: FilterParams) {
               nameWithOwner
               url
               stargazerCount
+              forkCount
               primaryLanguage {
                 name
               }
@@ -81,7 +82,8 @@ export async function fetchGitHubIssues(params: FilterParams) {
   const issues: Issue[] = response.search.nodes
     .filter((issue: any) => {
       const stars = issue.repository.stargazerCount
-      return stars >= params.minStars && stars <= params.maxStars
+      const forks = issue.repository.forkCount
+      return stars >= params.minStars && stars <= params.maxStars && forks >= params.minForks
     })
     .map((issue: any) => ({
       id: issue.url,
@@ -91,6 +93,7 @@ export async function fetchGitHubIssues(params: FilterParams) {
       repository_url: issue.repository.url,
       repository_name: issue.repository.nameWithOwner,
       stars_count: issue.repository.stargazerCount,
+      fork_count: issue.repository.forkCount,
       language: issue.repository.primaryLanguage?.name || null,
       is_assigned: issue.assignees.totalCount > 0,
       labels: issue.labels.nodes.map((label: any) => label.name),
@@ -134,6 +137,7 @@ export async function fetchGitHubIssuesByCategory(params: FilterParams) {
             nameWithOwner
             url
             stargazerCount
+            forkCount
             primaryLanguage {
               name
             }
@@ -164,6 +168,7 @@ export async function fetchGitHubIssuesByCategory(params: FilterParams) {
   let queryString = "is:public archived:false"
   if (params.language) queryString += ` language:${params.language}`
   queryString += ` stars:${params.minStars}..${params.maxStars}`
+  queryString += ` forks:>=${params.minForks}`
 
   if (params.category && params.category !== "all") {
     switch (params.category) {
@@ -216,6 +221,7 @@ export async function fetchGitHubIssuesByCategory(params: FilterParams) {
           repository_url: repo.url,
           repository_name: repo.nameWithOwner,
           stars_count: repo.stargazerCount,
+          forkCount: repo.forkCount,
           language: repo.primaryLanguage?.name || null,
           is_assigned: issue.assignees.totalCount > 0,
           labels: issue.labels.nodes.map((label: any) => label.name),
@@ -267,6 +273,7 @@ export async function fetchGitHubIssuesByFramework(params: FilterParams) {
             nameWithOwner
             url
             stargazerCount
+            forkCount
             primaryLanguage {
               name
             }
@@ -297,6 +304,7 @@ export async function fetchGitHubIssuesByFramework(params: FilterParams) {
   let queryString = `topic:${params.framework} is:public archived:false`
   if (params.language) queryString += ` language:${params.language}`
   queryString += ` stars:${params.minStars}..${params.maxStars}`
+  queryString += ` forks:>=${params.minForks}`
 
   console.log("GitHub framework query string:", queryString)
 
@@ -323,6 +331,7 @@ export async function fetchGitHubIssuesByFramework(params: FilterParams) {
           repository_url: repo.url,
           repository_name: repo.nameWithOwner,
           stars_count: repo.stargazerCount,
+          forkCount: repo.forkCount,
           language: repo.primaryLanguage?.name || null,
           is_assigned: issue.assignees.totalCount > 0,
           labels: issue.labels.nodes.map((label: any) => label.name),

--- a/app/services/gitlab.ts
+++ b/app/services/gitlab.ts
@@ -57,7 +57,9 @@ export async function fetchGitLabIssues(params: FilterParams) {
         created_at: issue.created_at,
         repository_url: projectData.web_url,
         repository_name: projectData.name_with_namespace,
+        archived: projectData.archived,
         stars_count: projectData.star_count,
+        forks_count: projectData.forks_count,
         language: projectData.repository_language,
         is_assigned: issue.assignees.length > 0,
         labels: issue.labels,
@@ -69,7 +71,9 @@ export async function fetchGitLabIssues(params: FilterParams) {
   const filteredIssues = issues.filter(
     (issue) =>
       issue.stars_count >= params.minStars &&
-      issue.stars_count <= params.maxStars
+      issue.stars_count <= params.maxStars &&
+      issue.forks_count >= params.minForks && 
+      issue.archived != true
   )
 
   return {
@@ -141,7 +145,9 @@ export async function fetchGitLabIssuesByCategory(params: FilterParams) {
         created_at: issue.created_at,
         repository_url: project.web_url,
         repository_name: project.name_with_namespace,
+        archived: project.archived,
         stars_count: project.star_count,
+        forks_count: project.forks_count,
         language: project.repository_language,
         is_assigned: issue.assignees.length > 0,
         labels: issue.labels,
@@ -154,6 +160,8 @@ export async function fetchGitLabIssuesByCategory(params: FilterParams) {
     (issue) =>
       issue.stars_count >= params.minStars &&
       issue.stars_count <= params.maxStars &&
+      issue.forks_count >= params.minForks &&
+      issue.archived != true &&
       (params.isAssigned || !issue.is_assigned)
   )
 
@@ -238,7 +246,9 @@ export async function fetchGitLabIssuesByFramework(params: FilterParams) {
         created_at: issue.created_at,
         repository_url: project.web_url,
         repository_name: project.name_with_namespace,
+        archived: project.archived,
         stars_count: project.star_count,
+        forks_count: project.forks_count,
         language: project.repository_language,
         is_assigned: issue.assignees.length > 0,
         labels: issue.labels,
@@ -251,6 +261,8 @@ export async function fetchGitLabIssuesByFramework(params: FilterParams) {
     (issue) =>
       issue.stars_count >= params.minStars &&
       issue.stars_count <= params.maxStars &&
+      issue.forks_count >= params.minForks &&
+      issue.archived != true &&
       (params.isAssigned || !issue.is_assigned)
   )
 


### PR DESCRIPTION
## ISSUES_ADDRESSED:
closes #37 --> Added a filter for minimum forks and filter out issues from repositories that are less than the mentioned minForks count from both GitHub and GitLab.

Note: @dotslashbit, Also added the archived repositories exclusion to the GitLab issues API


## SCREENSHOTS
![image](https://github.com/user-attachments/assets/755b5615-44c3-464c-90be-884f3db50dea)
![image](https://github.com/user-attachments/assets/3050adba-9fd5-4694-bf1d-f6a09ca6ea40)

![image](https://github.com/user-attachments/assets/b89a3e5f-7014-4215-930b-b20b7063ad5d)
![image](https://github.com/user-attachments/assets/ef7fc495-1163-4f79-a5e1-da79e598e909)

