### PR TITLE
FIX: Updated the github API query to only fetch LICENSED repos

### DIFF
--- a/app/services/github.ts
+++ b/app/services/github.ts
@@ -33,6 +33,9 @@ export async function fetchGitHubIssues(params: FilterParams) {
               nameWithOwner
               url
               stargazerCount
+              licenseInfo{
+                name   
+              }
               forkCount
               primaryLanguage {
                 name
@@ -58,7 +61,7 @@ export async function fetchGitHubIssues(params: FilterParams) {
     }
   `
 
-  let queryString = 'is:open is:issue label:"good first issue" archived:false'
+  let queryString = 'is:open is:issue label:"good first issue" archived:false is:public archived:false'
   if (params.language) queryString += ` language:${params.language}`
   if (params.isAssigned) {
     queryString += " assigned:*"
@@ -81,9 +84,10 @@ export async function fetchGitHubIssues(params: FilterParams) {
 
   const issues: Issue[] = response.search.nodes
     .filter((issue: any) => {
+      const isLicensed = Boolean(issue.repository.licenseInfo)
       const stars = issue.repository.stargazerCount
       const forks = issue.repository.forkCount
-      return stars >= params.minStars && stars <= params.maxStars && forks >= params.minForks
+      return stars >= params.minStars && stars <= params.maxStars && forks >= params.minForks && isLicensed
     })
     .map((issue: any) => ({
       id: issue.url,

--- a/app/services/github.ts
+++ b/app/services/github.ts
@@ -61,7 +61,7 @@ export async function fetchGitHubIssues(params: FilterParams) {
     }
   `
 
-  let queryString = 'is:open is:issue label:"good first issue" archived:false is:public archived:false'
+  let queryString = 'is:open is:issue label:"good first issue" archived:false'
   if (params.language) queryString += ` language:${params.language}`
   if (params.isAssigned) {
     queryString += " assigned:*"


### PR DESCRIPTION
fixes #47 

**Description**
This pull request addresses an issue where the GitHub API query was fetching repositories without checking for a license. The query has been updated to filter repositories that have a license.

**Note**
@dotslashbit The query request is for fetching github issues. As per my research we can not actually filter for license while fetching issues in "graphql" api.  Github's REST api has this filtering for license feature. That is why I applied filter on issues after fetching it. And show users issues only from licensed repositories.

I have tested code on local setup. Have a look at the screen recording attached below. 
Please review the code. Let me know if there is any mistake.

[screen-capture (1).webm](https://github.com/user-attachments/assets/313f0356-46bb-4092-9fbb-47435dcc54d2)
