### PR TITLE
Added backend keyword search functionality

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -52,6 +52,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     category: url.searchParams.get("category") || "all",
     framework: url.searchParams.get("framework") || "",
     hasPullRequests: url.searchParams.get("hasPullRequests") === "true",
+    searchQuery: url.searchParams.get("searchQuery") || "",
   }
 
   try {
@@ -130,6 +131,7 @@ export default function Index() {
     setFramework(url.searchParams.get("framework") || "")
     setHasPullRequests(url.searchParams.get("hasPullRequests") === "true")
     setShowBookmarked(url.searchParams.get("showBookmarked") === "true")
+    setMobileSearchQuery(url.searchParams.get("searchQuery") || "")
   }, [])
 
   useEffect(() => {
@@ -173,6 +175,7 @@ export default function Index() {
     formData.set("framework", framework)
     formData.set("hasPullRequests", hasPullRequests.toString())
     formData.set("showBookmarked", showBookmarked.toString())
+    formData.set("searchQuery", mobileSearchQuery)
     formData.set("cursor", endCursor || "")
     setIsSearching(true)
     submit(formData, { method: "get" })
@@ -191,6 +194,7 @@ export default function Index() {
     formData.set("framework", framework)
     formData.set("hasPullRequests", hasPullRequests.toString())
     formData.set("showBookmarked", showBookmarked.toString())
+    formData.set("searchQuery", mobileSearchQuery)
     setIssues([])
     setIsSearching(true)
     submit(formData, { method: "get" })
@@ -214,12 +218,13 @@ export default function Index() {
     formData.set("minStars", minStars)
     formData.set("maxStars", maxStars)
     formData.set("minForks", minForks)
-    formData.set("language", mobileSearchQuery)
+    formData.set("language", language)
     formData.set("isAssigned", isAssigned.toString())
     formData.set("category", category)
     formData.set("framework", framework)
     formData.set("hasPullRequests", hasPullRequests.toString())
     formData.set("showBookmarked", showBookmarked.toString())
+    formData.set("searchQuery", mobileSearchQuery)
     setIssues([])
     setIsSearching(true)
     submit(formData, { method: "get" })
@@ -241,6 +246,7 @@ export default function Index() {
       formData.append(key, value.toString())
     })
     formData.set('service', service)
+    formData.set('searchQuery', mobileSearchQuery)
     setIssues([])
     setIsSearching(true)
     submit(formData, { method: "get" })

--- a/app/services/github.ts
+++ b/app/services/github.ts
@@ -82,6 +82,9 @@ export async function fetchGitHubIssues(params: FilterParams) {
   } else {
     queryString += " -linked:pr"
   }
+  if (params.searchQuery) {
+    queryString += ` ${params.searchQuery} in:title,body`
+  }
   queryString += " sort:created-desc"
 
   const variables = {
@@ -231,6 +234,10 @@ export async function fetchGitHubIssuesByCategory(params: FilterParams) {
     }
   }
 
+  if (params.searchQuery) {
+    queryString += ` ${params.searchQuery} in:name,description`
+  }
+
   const variables = {
     queryString,
     cursor: params.cursor,
@@ -340,6 +347,9 @@ export async function fetchGitHubIssuesByFramework(params: FilterParams) {
   if (params.language) queryString += ` language:${params.language}`
   queryString += ` stars:${params.minStars}..${params.maxStars}`
   queryString += ` forks:>=${params.minForks}`
+  if (params.searchQuery) {
+    queryString += ` ${params.searchQuery} in:name,description`
+  }
 
   const variables = {
     queryString,


### PR DESCRIPTION
Resolves #53 

This allows the mobile UI search bar to accept keywords as input. I would eventually like this to return repository names, but I could not get the graphql query working.

[Screen recording 2024-08-29 11.40.50 PM.webm](https://github.com/user-attachments/assets/36232b0b-3bc5-46bc-92f1-0024b7c1c29b)
