### PR TITLE
Fix for Non-Scrollable Options in Dropdown Menu

### DIFF
--- a/app/components/FilterForm.tsx
+++ b/app/components/FilterForm.tsx
@@ -277,7 +277,9 @@ export function FilterForm({
                         <SelectTrigger className="w-full">
                           <SelectValue placeholder="Select a category" />
                         </SelectTrigger>
-                        <SelectContent className="bg-white dark:bg-gray-800 text-black dark:text-white p-3 border-2 border-gray-300 dark:border-transparent rounded-md shadow-lg w-full">
+                        <SelectContent className="bg-white dark:bg-gray-800 text-black dark:text-white p-3 
+                        border-2 border-gray-300 dark:border-transparent rounded-md shadow-lg  
+                         max-h-[--radix-select-content-available-height]" >
                           {categories.map((cat) => (
                             <SelectItem
                               key={cat.value}


### PR DESCRIPTION
**Problem**: I found an open-source repo, but I'm having an issue selecting options. The options are not scrollable, so not all of them are visible on the screen. When I scroll the webpage and reach the same height as the options, they become visible. If more options are added in the future, this will create a problem. The solution is to make the possibilities scrollable. Categories should be scrollable similar to language input scroll.

Solutions: 

https://github.com/user-attachments/assets/2c15d513-c711-42a1-92ad-a63b6b949eaf

